### PR TITLE
Preserve backwards compatibility of getAdmin

### DIFF
--- a/index.js
+++ b/index.js
@@ -391,7 +391,9 @@ class GoogleAuth extends DbBase {
     const displayKeys = ['email', 'level', 'blockPrivilege', 'company',
       'analyticsPrivilege', 'readOnly', 'active', 'timestamp']
 
-    return _.pick(admin, displayKeys)
+    return admin
+      ? _.pick(admin, displayKeys)
+      : admin
   }
 
   async _getAdmin (email, active = true) {


### PR DESCRIPTION
- [x] getAdmin should return false or undefined if admin is not found to preserve backwards compatibility