### PR TITLE
Support new Google Auth Response Format

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,8 @@ class GoogleAuth extends DbBase {
 
     const complete = (user)
       ? ['username', 'password'].every(k => k in user)
-      : ['access_token', 'token_type', 'expiry_date'].every(k => k in google)
+      : ['access_token', 'token_type', 'expiry_date'].every(k => k in google) ||
+        ['credential'].every(k => k in google)
     if (!complete) return cb(new Error('AUTH_FAC_LOGIN_KEYS_MISSING'))
 
     return (user)
@@ -254,6 +255,14 @@ class GoogleAuth extends DbBase {
 
   async googleEmailFromToken (token) {
     const oAuth2Client = await this._getOAuth2Client()
+    if (token?.credential) {
+      const ticket = await oAuth2Client.verifyIdToken({
+        idToken: token.credential
+      })
+
+      const payload = ticket.getPayload()
+      return payload.email
+    }
     oAuth2Client.setCredentials(token)
     const oauth2 = google.oauth2({ version: 'v2', auth: oAuth2Client })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-auth-google",
-  "version": "1.0.3",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-auth-google",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "private": false,
   "description": "Bitfinex Google Oauth Facility",
   "author": {


### PR DESCRIPTION
- [x] add support for new google response format. so endpoint now accepts `{ google: { credential } }`
- [x] maintain backwards compatibility for old format