### PR TITLE
Prevent admin password mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ class GoogleAuth extends DbBase {
       const adm = await this._getAdmin(email, false)
       if (adm) return adm
 
-      return this.addAdmin(admin)
+      return this.addAdmin({ ...admin })
     })
 
     await Promise.all(tasks)


### PR DESCRIPTION
The admin password data field `password` was corrupting during the migration by replacing it with the token.
This PR fix data mutation