### PR TITLE
Implement a feature to whitelist admin IPs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const migrations = require('./migrations')
 const { cloneDeep } = require('@bitfinex/lib-js-util-base')
 
 const FORMS_FIELD = 'forms'
+const JSON_FIELDS = [FORMS_FIELD, 'whitelistedIps']
 
 async function hash (password, salt = '') {
   return new Promise((resolve, reject) => {
@@ -559,7 +560,7 @@ class GoogleAuth extends DbBase {
 
       this.db.run(
         `INSERT INTO ${tableName} (${keys.join(', ')}) VALUES (${Array(keys.length).fill('?').join(', ')})`,
-        keys.map(key => (key === FORMS_FIELD || key === 'whitelistedIps') ? JSON.stringify(user[key]) : user[key]),
+        keys.map(key => JSON_FIELDS.includes(key) ? JSON.stringify(user[key]) : user[key]),
         function (err) {
           if (err) return reject(err)
 
@@ -660,7 +661,7 @@ class GoogleAuth extends DbBase {
 
       this.db.run(
         `UPDATE ${tableName} SET ${keys.join(' = ?, ')} = ? WHERE id = ?`,
-        keys.map(key => (key === FORMS_FIELD || key === 'whitelistedIps') ? JSON.stringify(user[key]) : user[key]).concat(adm.id),
+        keys.map(key => JSON_FIELDS.includes(key) ? JSON.stringify(user[key]) : user[key]).concat(adm.id),
         function (err) {
           if (err) return reject(err)
 
@@ -837,11 +838,8 @@ class GoogleAuth extends DbBase {
       'analyticsPrivilege', 'manageAdminsPrivilege', 'casesPrivilege', 'fetchMotivationsPrivilege', 'readOnly', 'active', 'timestamp', FORMS_FIELD, 'whitelistedIps']
 
     if (this.conf.useDB && admin) {
-      if (admin[FORMS_FIELD]) {
-        admin[FORMS_FIELD] = JSON.parse(admin[FORMS_FIELD])
-      }
-      if (admin.whitelistedIps) {
-        admin.whitelistedIps = JSON.parse(admin.whitelistedIps)
+      for (const field of JSON_FIELDS) {
+        if (admin[field]) admin[field] = JSON.parse(admin[field])
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ const tableName = 'admin_users'
  *  passwordResetToken?: string,
  *  passwordResetSentAt?: Date,
  *  company?: string,
- *  forms?: string[]
+ *  forms?: string[],
+ *  whitelistedIps?: string[]
  * }} BaseAdminT
  * @typedef { BaseAdminT & { password: string }} AddAdminT
  * @typedef { BaseAdminT & {
@@ -94,7 +95,8 @@ class GoogleAuth extends DbBase {
         passwordResetSentAt DATETIME,
         company TEXT,
         timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-        ${FORMS_FIELD} TEXT
+        ${FORMS_FIELD} TEXT,
+        whitelistedIps TEXT
       )`,
       `CREATE UNIQUE INDEX IF NOT EXISTS uidx_email ON ${tableName}(email ASC)`
     ]
@@ -494,7 +496,8 @@ class GoogleAuth extends DbBase {
       analyticsPrivilege,
       manageAdminsPrivilege,
       fetchMotivationsPrivilege,
-      company
+      company,
+      whitelistedIps
     } = user
 
     assert.ok(typeof email === 'string', 'Email is required')
@@ -528,6 +531,13 @@ class GoogleAuth extends DbBase {
       assert.ok(typeof company === 'string', 'company should be a string')
     }
 
+    if (whitelistedIps !== undefined) {
+      assert.ok(Array.isArray(whitelistedIps), 'whitelistedIps should be an array')
+      whitelistedIps.forEach((ip) => {
+        assert.ok(typeof ip === 'string', 'each whitelistedIps entry should be a string')
+      })
+    }
+
     const adm = await this._getAdmin(email, false)
     if (adm) throw new UserError('ADMIN_ACCOUNT_EXISTS')
 
@@ -542,7 +552,7 @@ class GoogleAuth extends DbBase {
 
       this.db.run(
         `INSERT INTO ${tableName} (${keys.join(', ')}) VALUES (${Array(keys.length).fill('?').join(', ')})`,
-        keys.map(key => key === FORMS_FIELD ? JSON.stringify(user[key]) : user[key]),
+        keys.map(key => (key === FORMS_FIELD || key === 'whitelistedIps') ? JSON.stringify(user[key]) : user[key]),
         function (err) {
           if (err) return reject(err)
 
@@ -555,6 +565,7 @@ class GoogleAuth extends DbBase {
             manageAdminsPrivilege,
             fetchMotivationsPrivilege,
             company,
+            whitelistedIps,
             active: true,
             id: this.lastID
           })
@@ -575,7 +586,8 @@ class GoogleAuth extends DbBase {
       manageAdminsPrivilege,
       fetchMotivationsPrivilege,
       company,
-      active
+      active,
+      whitelistedIps
     } = user
 
     assert.ok(typeof email === 'string', 'Email is required')
@@ -620,6 +632,13 @@ class GoogleAuth extends DbBase {
       assert.ok(typeof active === 'boolean', 'active should be a boolean')
     }
 
+    if (whitelistedIps !== undefined) {
+      assert.ok(Array.isArray(whitelistedIps), 'whitelistedIps should be an array')
+      whitelistedIps.forEach((ip) => {
+        assert.ok(typeof ip === 'string', 'each whitelistedIps entry should be a string')
+      })
+    }
+
     const adm = await this._getAdmin(email, !active)
     if (!adm) throw new UserError('ADMIN_ACCOUNT_DOES_NOT_EXIST_OR_IS_NOT_ACTIVE')
 
@@ -628,7 +647,7 @@ class GoogleAuth extends DbBase {
 
       this.db.run(
         `UPDATE ${tableName} SET ${keys.join(' = ?, ')} = ? WHERE id = ?`,
-        keys.map(key => user[key]).concat(adm.id),
+        keys.map(key => (key === FORMS_FIELD || key === 'whitelistedIps') ? JSON.stringify(user[key]) : user[key]).concat(adm.id),
         function (err) {
           if (err) return reject(err)
 
@@ -795,10 +814,15 @@ class GoogleAuth extends DbBase {
   async getAdmin (emailOrId, active = true, id = false) {
     const admin = await this._getAdmin(emailOrId, active, id)
     const displayKeys = ['email', 'level', 'blockPrivilege', 'company',
-      'analyticsPrivilege', 'manageAdminsPrivilege', 'fetchMotivationsPrivilege', 'readOnly', 'active', 'timestamp', FORMS_FIELD]
+      'analyticsPrivilege', 'manageAdminsPrivilege', 'fetchMotivationsPrivilege', 'readOnly', 'active', 'timestamp', FORMS_FIELD, 'whitelistedIps']
 
-    if (this.conf.useDB && admin && admin[FORMS_FIELD]) {
-      admin[FORMS_FIELD] = JSON.parse(admin[FORMS_FIELD])
+    if (this.conf.useDB && admin) {
+      if (admin[FORMS_FIELD]) {
+        admin[FORMS_FIELD] = JSON.parse(admin[FORMS_FIELD])
+      }
+      if (admin.whitelistedIps) {
+        admin.whitelistedIps = JSON.parse(admin.whitelistedIps)
+      }
     }
 
     return admin

--- a/migrations.js
+++ b/migrations.js
@@ -57,6 +57,17 @@ const migrations = [
         ADD fetchMotivationsPrivilege BOOLEAN
       `, cb)
     })
+  },
+  (_this, cb) => {
+    _this.db.all(`PRAGMA table_info(${tableName})`, [], (err, rows) => {
+      if (err) return cb(err)
+      if (rows?.find(row => row.name === 'whitelistedIps')) return cb()
+
+      _this.db.run(`
+        ALTER TABLE ${tableName}
+        ADD whitelistedIps TEXT
+      `, cb)
+    })
   }
 ]
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -197,4 +197,63 @@ describe('forms field', () => {
       assert.ok(!res)
     })
   })
+
+  describe('whitelistedIps field', () => {
+    const ips = ['192.168.1.1', '10.0.0.5']
+    const adminWithIps = {
+      email: testAdminEmail,
+      password: 'test123',
+      level: 0,
+      whitelistedIps: ips
+    }
+
+    it('should add admin and stringify whitelistedIps in the DB', async () => {
+      await authGoogle.addAdmin(adminWithIps)
+
+      await new Promise((resolve) => authGoogle.db.get('SELECT * FROM admin_users WHERE email=?', [testAdminEmail], (err, row) => {
+        if (err) throw err
+        assert.equal(row.whitelistedIps, JSON.stringify(ips))
+        resolve()
+      }))
+    })
+
+    it('should return whitelistedIps as a parsed array from getAdmin', async () => {
+      await authGoogle.addAdmin(adminWithIps)
+
+      const res = await authGoogle.getAdmin(testAdminEmail)
+
+      assert.deepEqual(res.whitelistedIps, ips)
+    })
+
+    it('should return undefined whitelistedIps when not set on admin', async () => {
+      await authGoogle.addAdmin({ email: testAdminEmail, password: 'test123', level: 0 })
+
+      const res = await authGoogle.getAdmin(testAdminEmail)
+
+      assert.equal(res.whitelistedIps, undefined)
+    })
+
+    it('should throw when adding admin with whitelistedIps not being an array', async () => {
+      try {
+        await authGoogle.addAdmin({ ...adminWithIps, whitelistedIps: '192.168.1.1' })
+        throw new Error('SHOULD_NOT_REACH_HERE')
+      } catch (e) {
+        assert.ok(e instanceof assert.AssertionError)
+        assert.strictEqual(e.message, 'whitelistedIps should be an array')
+      }
+    })
+
+
+    it('should update whitelistedIps and return the new list from getAdmin', async () => {
+      await authGoogle.addAdmin(adminWithIps)
+      const adminBeforeUpdate = await authGoogle.getAdmin(testAdminEmail)
+      assert.deepEqual(adminBeforeUpdate.whitelistedIps, ips)
+
+      const updatedIps = ['203.0.113.10']
+      await authGoogle.updateAdmin(testAdminEmail, { whitelistedIps: updatedIps })
+
+      const adminAfterUpdate = await authGoogle.getAdmin(testAdminEmail)
+      assert.deepEqual(adminAfterUpdate.whitelistedIps, updatedIps)
+    })
+  })
 })


### PR DESCRIPTION
Implement a feature to whitelist admin IPs

We should add the capability to only allow a list of admins for a particular admin if that has been set on the admin data. With this, if an admin has a list of whitelisted IPs, they can only login and access the platform from those IP addresses

[Asana ticket](https://app.asana.com/1/29923630752984/project/1206700099020666/task/1213857176190641)

Depends on this [PR](https://github.com/bitfinexcom/bfx-core-kyc-js/pull/1699)